### PR TITLE
feat:  party automation rules reflected in openapi spec

### DIFF
--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/OpenapiCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/OpenapiCommand.kt
@@ -5,10 +5,17 @@ import com.noumenadigital.npl.cli.exception.CommandExecutionException
 import com.noumenadigital.npl.cli.service.ColorWriter
 import com.noumenadigital.npl.cli.service.CompilerService
 import com.noumenadigital.npl.cli.service.SourcesManager
+import com.noumenadigital.npl.lang.Proto
 import com.noumenadigital.npl.lang.ProtocolProto
+import com.noumenadigital.npl.lang.Type
+import com.noumenadigital.npl.naming.TaggerUtils.untagged
+import com.noumenadigital.npl.party.assignment.models.PartyAssignments
+import com.noumenadigital.npl.party.assignment.parsing.PartyAssignmentRulesParser.parseYamlString
+import com.noumenadigital.npl.party.assignment.validation.PartyAssignmentRulesValidator
 import com.noumenadigital.platform.nplapi.ApiConfiguration
 import com.noumenadigital.platform.nplapi.openapi.OpenAPIGenerator
 import io.swagger.v3.core.util.Yaml
+import java.io.File
 import java.io.IOException
 import java.net.URI
 import java.net.URISyntaxException
@@ -18,6 +25,7 @@ import kotlin.io.path.notExists
 
 data class OpenapiCommand(
     private val srcDir: String = ".",
+    private val ruleDescriptorPath: String? = null,
     private val compilerService: CompilerService = CompilerService(SourcesManager(srcDir)),
 ) : CommandExecutor {
     override val commandName: String = "openapi"
@@ -31,6 +39,13 @@ data class OpenapiCommand(
                 defaultValue = ".",
                 isRequired = false,
                 valuePlaceholder = "<directory>",
+            ),
+            NamedParameter(
+                name = "--rulesDescriptor",
+                description =
+                    "Path to the party automation rules descriptor. If omitted, generated document will not reflect the current system",
+                isRequired = false,
+                valuePlaceholder = "<rules descriptor path>",
             ),
         )
 
@@ -47,7 +62,8 @@ data class OpenapiCommand(
         }
 
         val srcDir = parsedArgs.getValue("--sourceDir") ?: "."
-        return OpenapiCommand(srcDir = srcDir)
+        val rulesDescriptor = parsedArgs.getValue("--rulesDescriptor")
+        return OpenapiCommand(srcDir, rulesDescriptor)
     }
 
     override fun execute(output: ColorWriter): ExitCode {
@@ -57,6 +73,22 @@ data class OpenapiCommand(
                 output.error("Source directory does not exist: $srcDir")
                 return ExitCode.USAGE_ERROR
             }
+
+            val partyAssignments =
+                ruleDescriptorPath?.let {
+                    val file = File(it)
+                    if (it.isBlank() || !file.exists() || file.isDirectory) {
+                        output.error("Rules descriptor is invalid, blank or does not exist: $it")
+                        return ExitCode.USAGE_ERROR
+                    }
+
+                    try {
+                        parseYamlString(file.readText()).toPartyAssignments()
+                    } catch (e: Exception) {
+                        output.error("Failed while parsing the party automation rules: ${e.message}")
+                        return ExitCode.GENERAL_ERROR
+                    }
+                } ?: PartyAssignments()
 
             val compilationResult = compilerService.compileAndReport(output = output)
             if (compilationResult.hasErrors) {
@@ -88,7 +120,14 @@ data class OpenapiCommand(
                         throw CommandExecutionException("Failed to run openapi generation", e)
                     }
 
-                val openApi = apiGen.generate(protocols)
+                try {
+                    validatePartyRules(partyAssignments, compilationResult.protos)
+                } catch (e: Exception) {
+                    output.error("Failed while validating the Party automation rules: ${e.message}")
+                    return ExitCode.GENERAL_ERROR
+                }
+
+                val openApi = apiGen.generate(protocols, partyAssignments)
                 val packageName = packagePath.removePrefix().replace("/", ".")
 
                 writeToFile(
@@ -103,6 +142,22 @@ data class OpenapiCommand(
             return ExitCode.GENERAL_ERROR
         } catch (e: Exception) {
             throw CommandExecutionException("Failed to run NPL check: ${e.message}", e)
+        }
+    }
+
+    private fun validatePartyRules(
+        rules: PartyAssignments,
+        allProtos: List<Proto<Type>?>,
+    ) {
+        val protosMap = allProtos.filterIsInstance<ProtocolProto>().associateBy { it.protoId.toString().untagged() }
+
+        rules.ruleSet.forEach { rule ->
+            val proto = protosMap[rule.untaggedPrototypeId.toString()]
+
+            if (proto == null) {
+                error("No matching prototype found matching [" + rule.untaggedPrototypeId + "]")
+            }
+            PartyAssignmentRulesValidator.validateParties(rule, proto.actualType.parties)
         }
     }
 

--- a/src/main/resources/META-INF/native-image/reachability-metadata.json
+++ b/src/main/resources/META-INF/native-image/reachability-metadata.json
@@ -137,6 +137,9 @@
       ]
     },
     {
+      "type": "com.ethlo.time.ITU"
+    },
+    {
       "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
       "methods": [
         {
@@ -2100,6 +2103,9 @@
       "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
     },
     {
+      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
       "glob": "META-INF/services/javax.xml.parsers.DocumentBuilderFactory"
     },
     {
@@ -2116,6 +2122,15 @@
     },
     {
       "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "glob": "jsv-messages.properties"
+    },
+    {
+      "glob": "jsv-messages_en.properties"
+    },
+    {
+      "glob": "jsv-messages_en_CH.properties"
     },
     {
       "glob": "kotlin/collections/collections.kotlin_builtins"
@@ -2223,6 +2238,9 @@
       "glob": "org/fusesource/jansi/jansi.properties"
     },
     {
+      "glob": "party-assignment-schema-v1.json"
+    },
+    {
       "module": "java.base",
       "glob": "jdk/internal/icu/impl/data/icudt76b/nfc.nrm"
     },
@@ -2262,6 +2280,12 @@
         "en",
         "en-CH",
         "en-US"
+      ]
+    },
+    {
+      "name": "jsv-messages",
+      "locales": [
+        "en-CH"
       ]
     }
   ],

--- a/src/test/kotlin/com/noumenadigital/npl/cli/BinaryCommandsIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/BinaryCommandsIT.kt
@@ -53,6 +53,7 @@ class BinaryCommandsIT :
                                  --coverage  Report test coverage details (printed to console as well as coverage.xml)
                     openapi    Generate the openapi specifications of NPL api
                                  --sourceDir <directory>  Source directory containing NPL protocols (defaults to current directory)
+                                 --rulesDescriptor <rules descriptor path>  Path to the party automation rules descriptor. If omitted, generated document will not reflect the current system
                     puml       Generate a puml diagram from source in the given directory
                                  <directory>  Source directory containing NPL protocols (defaults to current directory)
                     deploy     Deploy NPL sources to a Noumena Engine instance

--- a/src/test/kotlin/com/noumenadigital/npl/cli/BinaryCommandsIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/BinaryCommandsIT.kt
@@ -52,7 +52,7 @@ class BinaryCommandsIT :
                                  --sourceDir <directory>  Source directory containing NPL tests to run (defaults to current directory)
                                  --coverage  Report test coverage details (printed to console as well as coverage.xml)
                     openapi    Generate the openapi specifications of NPL api
-                                 <directory>  Source directory containing NPL protocols (defaults to current directory)
+                                 --sourceDir <directory>  Source directory containing NPL protocols (defaults to current directory)
                     puml       Generate a puml diagram from source in the given directory
                                  <directory>  Source directory containing NPL protocols (defaults to current directory)
                     deploy     Deploy NPL sources to a Noumena Engine instance

--- a/src/test/kotlin/com/noumenadigital/npl/cli/OpenapiCommandIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/OpenapiCommandIT.kt
@@ -51,7 +51,7 @@ class OpenapiCommandIT :
             test("no protocols found") {
                 withOpenapiTestContext(testDir = listOf("success", "single_file")) {
                     runCommand(
-                        commands = listOf("openapi", absolutePath),
+                        commands = listOf("openapi", "--sourceDir", absolutePath),
                     ) {
                         process.waitFor()
                         val expectedOutput =
@@ -71,7 +71,7 @@ class OpenapiCommandIT :
             test("multiple files") {
                 withOpenapiTestContext(testDir = listOf("success", "multiple_files")) {
                     runCommand(
-                        commands = listOf("openapi", absolutePath),
+                        commands = listOf("openapi", "--sourceDir", absolutePath),
                     ) {
                         process.waitFor()
 
@@ -95,7 +95,7 @@ class OpenapiCommandIT :
             test("multiple packages") {
                 withOpenapiTestContext(testDir = listOf("success", "multiple_packages")) {
                     runCommand(
-                        commands = listOf("openapi", absolutePath),
+                        commands = listOf("openapi", "--sourceDir", absolutePath),
                     ) {
                         process.waitFor()
 
@@ -119,7 +119,7 @@ class OpenapiCommandIT :
             test("test failure") {
                 withOpenapiTestContext(testDir = listOf("success", "test_failure")) {
                     runCommand(
-                        commands = listOf("openapi", absolutePath),
+                        commands = listOf("openapi", "--sourceDir", absolutePath),
                     ) {
                         process.waitFor()
 
@@ -141,7 +141,7 @@ class OpenapiCommandIT :
                 test("multiple packages") {
                     withOpenapiTestContext(testDir = listOf("failure", "multiple_packages")) {
                         runCommand(
-                            commands = listOf("openapi", absolutePath),
+                            commands = listOf("openapi", "--sourceDir", absolutePath),
                         ) {
                             process.waitFor()
 
@@ -166,7 +166,7 @@ class OpenapiCommandIT :
                 test("warnings during compilation") {
                     withOpenapiTestContext(testDir = listOf("warnings", "compilation")) {
                         runCommand(
-                            commands = listOf("openapi", absolutePath),
+                            commands = listOf("openapi", "--sourceDir", absolutePath),
                         ) {
                             process.waitFor()
 
@@ -196,7 +196,7 @@ class OpenapiCommandIT :
                 test("no NPL sources") {
                     withOpenapiTestContext(testDir = listOf("warnings", "no_sources")) {
                         runCommand(
-                            commands = listOf("openapi", absolutePath),
+                            commands = listOf("openapi", "--sourceDir", absolutePath),
                         ) {
                             process.waitFor()
 

--- a/src/test/kotlin/com/noumenadigital/npl/cli/service/CommandProcessorServiceTest.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/service/CommandProcessorServiceTest.kt
@@ -41,7 +41,7 @@ class CommandProcessorServiceTest :
                                  --sourceDir <directory>  Source directory containing NPL tests to run (defaults to current directory)
                                  --coverage  Report test coverage details (printed to console as well as coverage.xml)
                     openapi    Generate the openapi specifications of NPL api
-                                 <directory>  Source directory containing NPL protocols (defaults to current directory)
+                                 --sourceDir <directory>  Source directory containing NPL protocols (defaults to current directory)
                     puml       Generate a puml diagram from source in the given directory
                                  <directory>  Source directory containing NPL protocols (defaults to current directory)
                     deploy     Deploy NPL sources to a Noumena Engine instance

--- a/src/test/kotlin/com/noumenadigital/npl/cli/service/CommandProcessorServiceTest.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/service/CommandProcessorServiceTest.kt
@@ -42,6 +42,7 @@ class CommandProcessorServiceTest :
                                  --coverage  Report test coverage details (printed to console as well as coverage.xml)
                     openapi    Generate the openapi specifications of NPL api
                                  --sourceDir <directory>  Source directory containing NPL protocols (defaults to current directory)
+                                 --rulesDescriptor <rules descriptor path>  Path to the party automation rules descriptor. If omitted, generated document will not reflect the current system
                     puml       Generate a puml diagram from source in the given directory
                                  <directory>  Source directory containing NPL protocols (defaults to current directory)
                     deploy     Deploy NPL sources to a Noumena Engine instance

--- a/src/test/resources/npl-sources/success/multiple_files/rule_descriptors/invalid_party.yml
+++ b/src/test/resources/npl-sources/success/multiple_files/rule_descriptors/invalid_party.yml
@@ -1,0 +1,6 @@
+objects.iou.Iou:
+  unknown:
+    set:
+      entity:
+        email:
+          - unknown@example.com

--- a/src/test/resources/npl-sources/success/multiple_files/rule_descriptors/invalid_protocol.yml
+++ b/src/test/resources/npl-sources/success/multiple_files/rule_descriptors/invalid_protocol.yml
@@ -1,0 +1,6 @@
+unknown.pkg.Iou:
+  issuer:
+    set:
+      entity:
+        email:
+          - issuer@example.com

--- a/src/test/resources/npl-sources/success/multiple_files/rule_descriptors/invalid_yaml.yml
+++ b/src/test/resources/npl-sources/success/multiple_files/rule_descriptors/invalid_yaml.yml
@@ -1,0 +1,3 @@
+Some
+ gibberish
+Invalid Yaml

--- a/src/test/resources/npl-sources/success/multiple_files/rule_descriptors/valid.yml
+++ b/src/test/resources/npl-sources/success/multiple_files/rule_descriptors/valid.yml
@@ -1,0 +1,11 @@
+objects.iou.Iou:
+  issuer:
+    set:
+      entity:
+        email:
+          - issuer@example.com
+processes.Settle:
+  carOwner:
+    extract:
+      entity:
+        - entity


### PR DESCRIPTION
When using the openapi command, a rule descriptor can be provided to reflect the given ruleset in the openapi specification.

Ticket: ST-4637
