### PR TITLE
Use slugs for cloud deployment

### DIFF
--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/cloud/CloudClearNplCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/cloud/CloudClearNplCommand.kt
@@ -27,13 +27,13 @@ class CloudClearNplCommand(
         listOf(
             NamedParameter(
                 name = "app",
-                description = "NOUMENA Cloud Application name",
+                description = "NOUMENA Cloud Application slug",
                 isRequired = true,
                 valuePlaceholder = "<app>",
             ),
             NamedParameter(
                 name = "tenant",
-                description = "NOUMENA Cloud Tenant name",
+                description = "NOUMENA Cloud Tenant slug",
                 isRequired = true,
                 valuePlaceholder = "<tenant>",
             ),

--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/cloud/CloudDeployNplCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/cloud/CloudDeployNplCommand.kt
@@ -38,13 +38,13 @@ class CloudDeployNplCommand(
         listOf(
             NamedParameter(
                 name = "app",
-                description = "NOUMENA Cloud Application name",
+                description = "NOUMENA Cloud Application slug",
                 isRequired = true,
                 valuePlaceholder = "<app>",
             ),
             NamedParameter(
                 name = "tenant",
-                description = "NOUMENA Cloud Tenant name",
+                description = "NOUMENA Cloud Tenant slug",
                 isRequired = true,
                 valuePlaceholder = "<tenant>",
             ),

--- a/src/main/kotlin/com/noumenadigital/npl/cli/http/NoumenaCloudClient.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/http/NoumenaCloudClient.kt
@@ -71,7 +71,7 @@ open class NoumenaCloudClient(
         try {
             val ncApp = findApplication(tenants)
             if (ncApp == null) {
-                throw CloudRestCallException("Application name ${config.app} doesn't exist for tenant ${config.tenant}")
+                throw CloudRestCallException("Application slug ${config.app} doesn't exist for tenant slug ${config.tenant}")
             }
             val deployUrl = "$ncBaseUrl/${ncApp.id}/deploy"
             val boundary = "----NoumenaBoundary" + UUID.randomUUID().toString().replace("-", "")
@@ -113,7 +113,7 @@ open class NoumenaCloudClient(
         try {
             val ncApp = findApplication(tenants)
             if (ncApp == null) {
-                throw CloudRestCallException("Application name ${config.app} doesn't exist for tenant ${config.tenant}")
+                throw CloudRestCallException("Application slug ${config.app} doesn't exist for tenant slug ${config.tenant}")
             }
             val clearUrl = "$ncBaseUrl/${ncApp.id}/clear"
             val httpDelete = HttpDelete(clearUrl)
@@ -134,7 +134,7 @@ open class NoumenaCloudClient(
 
     private fun findApplication(tenants: List<Tenant>): Application? =
         tenants
-            .find { it.name.equals(config.tenant, ignoreCase = true) }
+            .find { it.slug.equals(config.tenant, ignoreCase = true) }
             ?.applications
-            ?.find { it.name.equals(config.app, ignoreCase = true) }
+            ?.find { it.slug.equals(config.app, ignoreCase = true) }
 }

--- a/src/main/kotlin/com/noumenadigital/npl/cli/model/Application.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/model/Application.kt
@@ -6,4 +6,5 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 data class Application(
     val id: String,
     val name: String,
+    val slug: String,
 )

--- a/src/main/kotlin/com/noumenadigital/npl/cli/model/Tenant.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/model/Tenant.kt
@@ -5,5 +5,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Tenant(
     val name: String,
+    val slug: String,
     val applications: List<Application>,
 )

--- a/src/test/kotlin/com/noumenadigital/npl/cli/CloudClearCommandIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/CloudClearCommandIT.kt
@@ -294,7 +294,7 @@ class CloudClearCommandIT :
                         process.waitFor()
                         val expectedOutput =
                             """
-                            Command cloud clear failed: Failed to remove the application -  Application name existingName doesn't exist for tenant non-existing.
+                            Command cloud clear failed: Failed to remove the application -  Application slug existingName doesn't exist for tenant slug non-existing.
                             """.normalize()
 
                         output.normalize() shouldBe expectedOutput

--- a/src/test/kotlin/com/noumenadigital/npl/cli/CloudDeployCommandIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/CloudDeployCommandIT.kt
@@ -363,7 +363,7 @@ class CloudDeployCommandIT :
                         process.waitFor()
                         val expectedOutput =
                             """
-                            Command cloud deploy failed: Failed to upload application archive - Application name notExistingName doesn't exist for tenant default_tenant.
+                            Command cloud deploy failed: Failed to upload application archive - Application slug notExistingName doesn't exist for tenant slug default_tenant.
                             """.normalize()
 
                         output.normalize() shouldBe expectedOutput


### PR DESCRIPTION
<!-- Description of the PR changes -->
Updates `cloud deploy` and `cloud clear` commands to use tenant and application slugs instead of names for identification. This aligns the CLI with the API's use of slugs for more reliable and consistent resource identification.

Ticket: ST-XXXX