### PR TITLE
fix: Enforced all commands support relative and absolute pathing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -123,22 +123,6 @@
     }
   ],
   "results": {
-    "cloud.auth.http": [
-      {
-        "type": "JSON Web Token",
-        "filename": "cloud.auth.http",
-        "hashed_secret": "30bca28680dcf4cf68fc14890abfc74505536742",
-        "is_verified": false,
-        "line_number": 30
-      },
-      {
-        "type": "JSON Web Token",
-        "filename": "cloud.auth.http",
-        "hashed_secret": "64e2580a004b7e22694a78a31688eb726838e201",
-        "is_verified": false,
-        "line_number": 35
-      }
-    ],
     "src/main/resources/sample-deploy.yml": [
       {
         "type": "Secret Keyword",
@@ -182,14 +166,14 @@
         "filename": "src/test/kotlin/com/noumenadigital/npl/cli/DeployCommandIT.kt",
         "hashed_secret": "e38ad214943daad1d64c102faec29de4afe9da3d",
         "is_verified": false,
-        "line_number": 102
+        "line_number": 103
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/kotlin/com/noumenadigital/npl/cli/DeployCommandIT.kt",
         "hashed_secret": "2aa60a8ff7fcd473d321e0146afd9e26df395147",
         "is_verified": false,
-        "line_number": 111
+        "line_number": 112
       }
     ],
     "src/test/kotlin/com/noumenadigital/npl/cli/config/DeployConfigTest.kt": [
@@ -211,5 +195,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-02T09:00:09Z"
+  "generated_at": "2025-08-05T12:53:42Z"
 }

--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/CheckCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/CheckCommand.kt
@@ -7,6 +7,7 @@ import com.noumenadigital.npl.cli.exception.CommandExecutionException
 import com.noumenadigital.npl.cli.service.ColorWriter
 import com.noumenadigital.npl.cli.service.CompilerService
 import com.noumenadigital.npl.cli.service.SourcesManager
+import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
 import java.io.File
 
 data class CheckCommand(
@@ -45,20 +46,20 @@ data class CheckCommand(
             checkDirectory(srcDir)
             val result = compilerService.compileAndReport(output = output)
 
-            when {
+            return when {
                 result.hasErrors -> {
                     output.error("NPL check failed with errors.")
-                    return ExitCode.COMPILATION_ERROR
+                    ExitCode.COMPILATION_ERROR
                 }
 
                 result.hasWarnings -> {
                     output.warning("NPL check completed with warnings.")
-                    return ExitCode.GENERAL_ERROR
+                    ExitCode.GENERAL_ERROR
                 }
 
                 else -> {
                     output.success("NPL check completed successfully.")
-                    return ExitCode.SUCCESS
+                    ExitCode.SUCCESS
                 }
             }
         } catch (e: CommandExecutionException) {
@@ -73,11 +74,11 @@ data class CheckCommand(
         val dir = File(directory)
 
         if (!dir.exists()) {
-            throw CommandExecutionException("Target directory does not exist: $directory")
+            throw CommandExecutionException("Target directory does not exist: ${dir.relativeToCurrentOrAbsolute()}")
         }
 
         if (!dir.isDirectory) {
-            throw CommandExecutionException("Target path is not a directory: $directory")
+            throw CommandExecutionException("Target path is not a directory: ${dir.relativeToCurrentOrAbsolute()}")
         }
     }
 }

--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/CheckCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/CheckCommand.kt
@@ -7,7 +7,7 @@ import com.noumenadigital.npl.cli.exception.CommandExecutionException
 import com.noumenadigital.npl.cli.service.ColorWriter
 import com.noumenadigital.npl.cli.service.CompilerService
 import com.noumenadigital.npl.cli.service.SourcesManager
-import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
+import com.noumenadigital.npl.cli.util.relativeOrAbsolute
 import java.io.File
 
 data class CheckCommand(
@@ -74,11 +74,11 @@ data class CheckCommand(
         val dir = File(directory)
 
         if (!dir.exists()) {
-            throw CommandExecutionException("Target directory does not exist: ${dir.relativeToCurrentOrAbsolute()}")
+            throw CommandExecutionException("Target directory does not exist: ${dir.relativeOrAbsolute()}")
         }
 
         if (!dir.isDirectory) {
-            throw CommandExecutionException("Target path is not a directory: ${dir.relativeToCurrentOrAbsolute()}")
+            throw CommandExecutionException("Target path is not a directory: ${dir.relativeOrAbsolute()}")
         }
     }
 }

--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/DeployCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/DeployCommand.kt
@@ -9,6 +9,7 @@ import com.noumenadigital.npl.cli.exception.DeployConfigException
 import com.noumenadigital.npl.cli.service.ColorWriter
 import com.noumenadigital.npl.cli.service.DeployResult
 import com.noumenadigital.npl.cli.service.DeployService
+import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
 import java.io.File
 
 class DeployCommand(
@@ -75,11 +76,11 @@ class DeployCommand(
 
         val sourceDirFile = File(sourceDirValue)
         if (!sourceDirFile.exists()) {
-            output.error("Source directory does not exist: $sourceDirValue")
+            output.error("Source directory does not exist: ${sourceDirFile.relativeToCurrentOrAbsolute()}")
             return ExitCode.GENERAL_ERROR
         }
         if (!sourceDirFile.isDirectory) {
-            output.error("Source path is not a directory: $sourceDirValue")
+            output.error("Source path is not a directory: ${sourceDirFile.relativeToCurrentOrAbsolute()}")
             return ExitCode.GENERAL_ERROR
         }
 
@@ -150,20 +151,20 @@ class DeployCommand(
             }
         }
 
-        when (val deployResult = deployService.deploySourcesAndMigrations(targetConfig, sourceDirValue)) {
+        return when (val deployResult = deployService.deploySourcesAndMigrations(targetConfig, sourceDirValue)) {
             is DeployResult.Success -> {
                 output.success("Successfully deployed NPL sources and migrations to ${targetConfig.engineManagementUrl}.")
-                return ExitCode.SUCCESS
+                ExitCode.SUCCESS
             }
 
             is DeployResult.DeploymentFailed -> {
                 output.error("Error deploying NPL sources: ${deployResult.exception.message ?: "Unknown deployment failure"}")
-                return ExitCode.GENERAL_ERROR
+                ExitCode.GENERAL_ERROR
             }
 
             else -> {
                 output.error("Internal error: Unhandled deployment result state: $deployResult")
-                return ExitCode.INTERNAL_ERROR
+                ExitCode.INTERNAL_ERROR
             }
         }
     }

--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/DeployCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/DeployCommand.kt
@@ -9,7 +9,7 @@ import com.noumenadigital.npl.cli.exception.DeployConfigException
 import com.noumenadigital.npl.cli.service.ColorWriter
 import com.noumenadigital.npl.cli.service.DeployResult
 import com.noumenadigital.npl.cli.service.DeployService
-import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
+import com.noumenadigital.npl.cli.util.relativeOrAbsolute
 import java.io.File
 
 class DeployCommand(
@@ -76,11 +76,11 @@ class DeployCommand(
 
         val sourceDirFile = File(sourceDirValue)
         if (!sourceDirFile.exists()) {
-            output.error("Source directory does not exist: ${sourceDirFile.relativeToCurrentOrAbsolute()}")
+            output.error("Source directory does not exist: ${sourceDirFile.relativeOrAbsolute()}")
             return ExitCode.GENERAL_ERROR
         }
         if (!sourceDirFile.isDirectory) {
-            output.error("Source path is not a directory: ${sourceDirFile.relativeToCurrentOrAbsolute()}")
+            output.error("Source path is not a directory: ${sourceDirFile.relativeOrAbsolute()}")
             return ExitCode.GENERAL_ERROR
         }
 

--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/InitCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/InitCommand.kt
@@ -8,6 +8,7 @@ import com.noumenadigital.npl.cli.http.NoumenaGitRepoClient.Companion.SupportedB
 import com.noumenadigital.npl.cli.http.NoumenaGitRepoClient.Companion.SupportedBranches.SAMPLES
 import com.noumenadigital.npl.cli.service.ColorWriter
 import com.noumenadigital.npl.cli.util.ZipExtractor
+import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
 import java.io.File
 import java.util.UUID
 
@@ -18,14 +19,14 @@ class InitCommand(
 
     override val commandName: String = "init"
     override val description: String = "Initializes a new project"
-    override val supportsMcp: Boolean = false // TODO: ST-4767
+    override val supportsMcp: Boolean = false
 
     override val parameters: List<NamedParameter> =
         listOf(
             NamedParameter(
-                name = "name",
-                description = "Name of the project. A directory of this name will be created in the current directory",
-                valuePlaceholder = "<name>",
+                name = "projectDir",
+                description = "Directory where project files will be stored. Created if it doesn’t exist",
+                valuePlaceholder = "<projectDir>",
             ),
             NamedParameter(
                 name = "bare",
@@ -60,16 +61,16 @@ class InitCommand(
             return ExitCode.USAGE_ERROR
         }
 
-        val projectName = parsedArgs.getValue("name")
+        val projectPath = parsedArgs.getValue("projectDir")
         val projectDir =
-            projectName?.let {
+            projectPath?.let {
                 File(it).apply {
                     if (exists()) {
-                        output.displayError("Directory $canonicalPath already exists.")
+                        output.displayError("Directory ${relativeToCurrentOrAbsolute()} already exists.")
                         return ExitCode.GENERAL_ERROR
                     }
                     if (!mkdir()) {
-                        output.displayError("Failed to create directory $canonicalFile.")
+                        output.displayError("Failed to create directory ${relativeToCurrentOrAbsolute()}.")
                         return ExitCode.GENERAL_ERROR
                     }
                 }
@@ -88,7 +89,7 @@ class InitCommand(
 
         try {
             ZipExtractor.unzip(archiveFile, skipTopDirectory = true, errorOnConflict = true)
-            output.info("Project successfully saved to ${projectDir.absolutePath}")
+            output.info("Project successfully saved to ${projectDir.relativeToCurrentOrAbsolute()}")
         } catch (e: Exception) {
             output.displayError("Failed to extract project files. ${e.message}")
             return ExitCode.GENERAL_ERROR

--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/InitCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/InitCommand.kt
@@ -8,7 +8,7 @@ import com.noumenadigital.npl.cli.http.NoumenaGitRepoClient.Companion.SupportedB
 import com.noumenadigital.npl.cli.http.NoumenaGitRepoClient.Companion.SupportedBranches.SAMPLES
 import com.noumenadigital.npl.cli.service.ColorWriter
 import com.noumenadigital.npl.cli.util.ZipExtractor
-import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
+import com.noumenadigital.npl.cli.util.relativeOrAbsolute
 import java.io.File
 import java.util.UUID
 
@@ -66,11 +66,11 @@ class InitCommand(
             projectPath?.let {
                 File(it).apply {
                     if (exists()) {
-                        output.displayError("Directory ${relativeToCurrentOrAbsolute()} already exists.")
+                        output.displayError("Directory ${relativeOrAbsolute()} already exists.")
                         return ExitCode.GENERAL_ERROR
                     }
                     if (!mkdir()) {
-                        output.displayError("Failed to create directory ${relativeToCurrentOrAbsolute()}.")
+                        output.displayError("Failed to create directory ${relativeOrAbsolute()}.")
                         return ExitCode.GENERAL_ERROR
                     }
                 }
@@ -89,7 +89,7 @@ class InitCommand(
 
         try {
             ZipExtractor.unzip(archiveFile, skipTopDirectory = true, errorOnConflict = true)
-            output.info("Project successfully saved to ${projectDir.relativeToCurrentOrAbsolute()}")
+            output.info("Project successfully saved to ${projectDir.relativeOrAbsolute()}")
         } catch (e: Exception) {
             output.displayError("Failed to extract project files. ${e.message}")
             return ExitCode.GENERAL_ERROR

--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/OpenapiCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/OpenapiCommand.kt
@@ -7,7 +7,7 @@ import com.noumenadigital.npl.cli.exception.CommandExecutionException
 import com.noumenadigital.npl.cli.service.ColorWriter
 import com.noumenadigital.npl.cli.service.CompilerService
 import com.noumenadigital.npl.cli.service.SourcesManager
-import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
+import com.noumenadigital.npl.cli.util.relativeOrAbsolute
 import com.noumenadigital.npl.lang.Proto
 import com.noumenadigital.npl.lang.ProtocolProto
 import com.noumenadigital.npl.lang.Type
@@ -88,7 +88,7 @@ data class OpenapiCommand(
         try {
             val sourcePath = Paths.get(srcDir)
             if (sourcePath.notExists()) {
-                output.error("Source directory does not exist: ${File(srcDir).relativeToCurrentOrAbsolute()}")
+                output.error("Source directory does not exist: ${File(srcDir).relativeOrAbsolute()}")
                 return ExitCode.USAGE_ERROR
             }
 

--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/OpenapiCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/OpenapiCommand.kt
@@ -7,6 +7,7 @@ import com.noumenadigital.npl.cli.exception.CommandExecutionException
 import com.noumenadigital.npl.cli.service.ColorWriter
 import com.noumenadigital.npl.cli.service.CompilerService
 import com.noumenadigital.npl.cli.service.SourcesManager
+import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
 import com.noumenadigital.npl.lang.Proto
 import com.noumenadigital.npl.lang.ProtocolProto
 import com.noumenadigital.npl.lang.Type
@@ -77,7 +78,7 @@ data class OpenapiCommand(
             throw CommandExecutionException("Unknown arguments: ${parsedArgs.unexpectedArgs.joinToString(" ")}")
         }
 
-        val srcDir = parsedArgs.getValue("sourceDir") ?: "."
+        val srcDir = parsedArgs.getValue("sourceDir") ?: CURRENT_DIRECTORY
         val rules = parsedArgs.getValue("rules")
         val outputDir = parsedArgs.getValue("outputDir") ?: CURRENT_DIRECTORY
         return OpenapiCommand(srcDir, rules, outputDir)
@@ -87,7 +88,7 @@ data class OpenapiCommand(
         try {
             val sourcePath = Paths.get(srcDir)
             if (sourcePath.notExists()) {
-                output.error("Source directory does not exist: $srcDir")
+                output.error("Source directory does not exist: ${File(srcDir).relativeToCurrentOrAbsolute()}")
                 return ExitCode.USAGE_ERROR
             }
 

--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/PumlCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/PumlCommand.kt
@@ -9,7 +9,7 @@ import com.noumenadigital.npl.cli.exception.CommandExecutionException
 import com.noumenadigital.npl.cli.service.ColorWriter
 import com.noumenadigital.npl.cli.service.CompilerService
 import com.noumenadigital.npl.cli.service.SourcesManager
-import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
+import com.noumenadigital.npl.cli.util.relativeOrAbsolute
 import com.noumenadigital.pumlgen.NplPumlObjectGenerator.generateFiles
 import java.io.File
 
@@ -47,7 +47,7 @@ data class PumlCommand(
             File(srcDir).let {
                 if (!it.isDirectory() || !it.exists()) {
                     throw CommandExecutionException(
-                        "Source directory does not exist or is not a directory: ${it.relativeToCurrentOrAbsolute()}",
+                        "Source directory does not exist or is not a directory: ${it.relativeOrAbsolute()}",
                     )
                 }
             }
@@ -62,7 +62,7 @@ data class PumlCommand(
             val pumlFiles = generateFiles(protosMap)
 
             outputDirFile.mkdirs()
-            output.info("Writing Puml files to ${outputDirFile.relativeToCurrentOrAbsolute()}\n")
+            output.info("Writing Puml files to ${outputDirFile.relativeOrAbsolute()}\n")
 
             pumlFiles.forEach {
                 try {

--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/PumlCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/PumlCommand.kt
@@ -9,6 +9,7 @@ import com.noumenadigital.npl.cli.exception.CommandExecutionException
 import com.noumenadigital.npl.cli.service.ColorWriter
 import com.noumenadigital.npl.cli.service.CompilerService
 import com.noumenadigital.npl.cli.service.SourcesManager
+import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
 import com.noumenadigital.pumlgen.NplPumlObjectGenerator.generateFiles
 import java.io.File
 
@@ -43,8 +44,12 @@ data class PumlCommand(
 
     override fun execute(output: ColorWriter): ExitCode {
         try {
-            if (!File(srcDir).isDirectory() || !File(srcDir).exists()) {
-                throw CommandExecutionException("Source directory does not exist or is not a directory: $srcDir")
+            File(srcDir).let {
+                if (!it.isDirectory() || !it.exists()) {
+                    throw CommandExecutionException(
+                        "Source directory does not exist or is not a directory: ${it.relativeToCurrentOrAbsolute()}",
+                    )
+                }
             }
 
             val outputDirFile = File(outputDir).resolve("puml")
@@ -57,7 +62,7 @@ data class PumlCommand(
             val pumlFiles = generateFiles(protosMap)
 
             outputDirFile.mkdirs()
-            output.info("Writing Puml files to ${outputDirFile.canonicalPath}\n")
+            output.info("Writing Puml files to ${outputDirFile.relativeToCurrentOrAbsolute()}\n")
 
             pumlFiles.forEach {
                 try {

--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/TestCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/TestCommand.kt
@@ -8,7 +8,7 @@ import com.noumenadigital.npl.cli.service.ColorWriter
 import com.noumenadigital.npl.cli.service.SourcesManager
 import com.noumenadigital.npl.cli.service.TestHarness
 import com.noumenadigital.npl.cli.util.normalizeWindowsPath
-import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
+import com.noumenadigital.npl.cli.util.relativeOrAbsolute
 import com.noumenadigital.npl.testing.coverage.CoverageAnalyzer
 import com.noumenadigital.npl.testing.coverage.LineCoverageAnalyzer
 import com.noumenadigital.npl.testing.coverage.NoCoverageAnalyzer
@@ -72,7 +72,7 @@ data class TestCommand(
             val sourceDir = File(sourcePath)
             if (!sourceDir.isDirectory || !sourceDir.exists()) {
                 output.error(
-                    "Given source directory is either not a directory or does not exist. ${sourceDir.relativeToCurrentOrAbsolute()}",
+                    "Given source directory is either not a directory or does not exist. ${sourceDir.relativeOrAbsolute()}",
                 )
                 return ExitCode.GENERAL_ERROR
             }

--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/TestCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/TestCommand.kt
@@ -8,6 +8,7 @@ import com.noumenadigital.npl.cli.service.ColorWriter
 import com.noumenadigital.npl.cli.service.SourcesManager
 import com.noumenadigital.npl.cli.service.TestHarness
 import com.noumenadigital.npl.cli.util.normalizeWindowsPath
+import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
 import com.noumenadigital.npl.testing.coverage.CoverageAnalyzer
 import com.noumenadigital.npl.testing.coverage.LineCoverageAnalyzer
 import com.noumenadigital.npl.testing.coverage.NoCoverageAnalyzer
@@ -70,7 +71,9 @@ data class TestCommand(
             val sourcePath = parsedArgs.getValue("sourceDir") ?: "."
             val sourceDir = File(sourcePath)
             if (!sourceDir.isDirectory || !sourceDir.exists()) {
-                output.error("Given source directory is either not a directory or does not exist. ${sourceDir.canonicalPath}")
+                output.error(
+                    "Given source directory is either not a directory or does not exist. ${sourceDir.relativeToCurrentOrAbsolute()}",
+                )
                 return ExitCode.GENERAL_ERROR
             }
 

--- a/src/main/kotlin/com/noumenadigital/npl/cli/util/FileUtils.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/util/FileUtils.kt
@@ -1,8 +1,6 @@
 package com.noumenadigital.npl.cli.util
 
 import java.io.File
-import java.nio.file.Path
-import java.nio.file.Paths
 
 object FileUtils {
     fun findFiles(
@@ -15,11 +13,13 @@ object FileUtils {
             .toList()
 }
 
-fun File.relativeToCurrentOrAbsolute(): String = relativeToOrNull(File("."))?.path?.takeIf { it.isNotBlank() } ?: absolutePath
+fun File.relativeOrAbsolute(): String {
+    val dirPath = normalize().absolutePath
+    val currentPath = File(".").normalize().absolutePath
 
-fun Path.relativeToCurrent(): Path =
-    Paths
-        .get(".")
-        .toAbsolutePath()
-        .normalize()
-        .relativize(this)
+    return if (dirPath.startsWith(currentPath)) {
+        dirPath.replace(currentPath.plus("/"), "")
+    } else {
+        absolutePath
+    }
+}

--- a/src/main/kotlin/com/noumenadigital/npl/cli/util/FileUtils.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/util/FileUtils.kt
@@ -1,7 +1,7 @@
 package com.noumenadigital.npl.cli.util
 
-import kotlinx.io.files.SystemPathSeparator
 import java.io.File
+import java.nio.file.Paths
 
 object FileUtils {
     fun findFiles(
@@ -18,8 +18,8 @@ fun File.relativeOrAbsolute(): String {
     val dirPath = normalize().absolutePath
     val currentPath = File(".").normalize().absolutePath
 
-    return if (dirPath.startsWith(currentPath)) {
-        dirPath.replace(currentPath.plus(SystemPathSeparator), "")
+    return if (dirPath != currentPath && dirPath.startsWith(currentPath)) {
+        Paths.get(currentPath).relativize(Paths.get(dirPath)).toString()
     } else {
         absolutePath
     }

--- a/src/main/kotlin/com/noumenadigital/npl/cli/util/FileUtils.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/util/FileUtils.kt
@@ -1,5 +1,6 @@
 package com.noumenadigital.npl.cli.util
 
+import kotlinx.io.files.SystemPathSeparator
 import java.io.File
 
 object FileUtils {
@@ -18,7 +19,7 @@ fun File.relativeOrAbsolute(): String {
     val currentPath = File(".").normalize().absolutePath
 
     return if (dirPath.startsWith(currentPath)) {
-        dirPath.replace(currentPath.plus("/"), "")
+        dirPath.replace(currentPath.plus(SystemPathSeparator), "")
     } else {
         absolutePath
     }

--- a/src/main/kotlin/com/noumenadigital/npl/cli/util/FileUtils.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/util/FileUtils.kt
@@ -1,6 +1,8 @@
 package com.noumenadigital.npl.cli.util
 
 import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
 
 object FileUtils {
     fun findFiles(
@@ -12,3 +14,12 @@ object FileUtils {
             .filter { it.isFile && it.name.equals(fileName, ignoreCase = true) }
             .toList()
 }
+
+fun File.relativeToCurrentOrAbsolute(): String = relativeToOrNull(File("."))?.path?.takeIf { it.isNotBlank() } ?: absolutePath
+
+fun Path.relativeToCurrent(): Path =
+    Paths
+        .get(".")
+        .toAbsolutePath()
+        .normalize()
+        .relativize(this)

--- a/src/test/kotlin/com/noumenadigital/npl/cli/BinaryCommandsIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/BinaryCommandsIT.kt
@@ -47,7 +47,7 @@ class BinaryCommandsIT :
                     version    Display the current version of the NPL CLI
                     help       Display the description for npl-cli commands
                     init       Initializes a new project
-                                 --name <name>  Name of the project. A directory of this name will be created in the current directory
+                                 --projectDir <projectDir>  Directory where project files will be stored. Created if it doesn’t exist
                                  --bare  Installs an empty project structure (defaults to false)
                                  --templateUrl <templateUrl>  URL of a repository containing a ZIP archive of the project template. Overrides the default template
                     check      Validate the correctness of NPL sources

--- a/src/test/kotlin/com/noumenadigital/npl/cli/CheckCommandIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/CheckCommandIT.kt
@@ -30,6 +30,29 @@ class CheckCommandIT :
                 }
             }
 
+            test("single file - relative path") {
+                val testDirPath =
+                    getTestResourcesPath(listOf("success", "single_file"))
+                        .let {
+                            File(".").canonicalFile.toPath().relativize(it)
+                        }.toString()
+                runCommand(
+                    commands = listOf("check", "--sourceDir", testDirPath),
+                ) {
+                    process.waitFor()
+
+                    val expectedOutput =
+                        """
+                    Completed compilation for 1 file in XXX ms
+
+                    NPL check completed successfully.
+                    """.normalize()
+
+                    output.normalize() shouldBe expectedOutput
+                    process.exitValue() shouldBe ExitCode.SUCCESS.code
+                }
+            }
+
             test("multiple files") {
                 val testDirPath =
                     getTestResourcesPath(listOf("success", "multiple_files")).toAbsolutePath().toString()

--- a/src/test/kotlin/com/noumenadigital/npl/cli/CheckCommandIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/CheckCommandIT.kt
@@ -3,6 +3,7 @@ package com.noumenadigital.npl.cli
 import com.noumenadigital.npl.cli.TestUtils.getTestResourcesPath
 import com.noumenadigital.npl.cli.TestUtils.normalize
 import com.noumenadigital.npl.cli.TestUtils.runCommand
+import com.noumenadigital.npl.cli.util.relativeOrAbsolute
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import java.io.File
@@ -295,7 +296,7 @@ class CheckCommandIT :
 
                     val expectedOutput =
                         """
-                    Target directory does not exist: $nonExistentPath
+                    Target directory does not exist: ${nonExistentPath.toFile().relativeOrAbsolute()}
                     """.normalize()
 
                     output.normalize() shouldBe expectedOutput
@@ -315,7 +316,7 @@ class CheckCommandIT :
 
                     val expectedOutput =
                         """
-                    Target path is not a directory: ${tempFile.absolutePath}
+                    Target path is not a directory: ${tempFile.relativeOrAbsolute()}
                     """.normalize()
 
                     output.normalize() shouldBe expectedOutput

--- a/src/test/kotlin/com/noumenadigital/npl/cli/DeployCommandIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/DeployCommandIT.kt
@@ -9,7 +9,7 @@ import com.noumenadigital.npl.cli.TestUtils.runCommand
 import com.noumenadigital.npl.cli.commands.registry.DeployCommand
 import com.noumenadigital.npl.cli.config.DeployConfig
 import com.noumenadigital.npl.cli.config.EngineTargetConfig
-import com.noumenadigital.npl.cli.util.relativeToCurrent
+import com.noumenadigital.npl.cli.util.relativeOrAbsolute
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import okhttp3.mockwebserver.Dispatcher
@@ -222,7 +222,7 @@ class DeployCommandIT :
                     createConfigFile(tempDir, engineUrl, oidcUrl)
 
                     val testDirPath =
-                        getTestResourcesPath(listOf("deploy-success", "main")).relativeToCurrent().toString()
+                        getTestResourcesPath(listOf("deploy-success", "main")).toFile().relativeOrAbsolute().toString()
 
                     val (output, exitCode) = executeDeployCommand(tempDir, testDirPath)
 

--- a/src/test/kotlin/com/noumenadigital/npl/cli/DeployCommandIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/DeployCommandIT.kt
@@ -9,6 +9,7 @@ import com.noumenadigital.npl.cli.TestUtils.runCommand
 import com.noumenadigital.npl.cli.commands.registry.DeployCommand
 import com.noumenadigital.npl.cli.config.DeployConfig
 import com.noumenadigital.npl.cli.config.EngineTargetConfig
+import com.noumenadigital.npl.cli.util.relativeToCurrent
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import okhttp3.mockwebserver.Dispatcher
@@ -192,6 +193,36 @@ class DeployCommandIT :
 
                     val testDirPath =
                         getTestResourcesPath(listOf("deploy-success", "main")).toAbsolutePath().toString()
+
+                    val (output, exitCode) = executeDeployCommand(tempDir, testDirPath)
+
+                    output.normalize() shouldBe
+                        """
+                        Successfully deployed NPL sources and migrations to $engineUrl.
+                        """.trimIndent()
+                    exitCode shouldBe ExitCode.SUCCESS.code
+                } finally {
+                    tempDir.deleteRecursively()
+                }
+            }
+
+            test("simple deploy - relative path") {
+                mockEngine.enqueue(
+                    MockResponse()
+                        .setResponseCode(200)
+                        .setHeader("Content-Type", "application/json")
+                        .setBody("{}"),
+                )
+
+                val engineUrl = mockEngine.url("/").toString()
+                val oidcUrl = mockOidc.url("/").toString()
+
+                val tempDir = Files.createTempDirectory("npl-cli-test").toFile()
+                try {
+                    createConfigFile(tempDir, engineUrl, oidcUrl)
+
+                    val testDirPath =
+                        getTestResourcesPath(listOf("deploy-success", "main")).relativeToCurrent().toString()
 
                     val (output, exitCode) = executeDeployCommand(tempDir, testDirPath)
 

--- a/src/test/kotlin/com/noumenadigital/npl/cli/InitCommandIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/InitCommandIT.kt
@@ -170,7 +170,7 @@ class InitCommandIT :
                     val expectedOutput =
                         """
                     Successfully downloaded project files
-                    Project successfully saved to ${workingDirectory.normalize().absolutePath}
+                    Project successfully saved to ${workingDirectory.absolutePath.normalize()}
                     """.normalize()
 
                     (commonFiles + newFiles).forEach {

--- a/src/test/kotlin/com/noumenadigital/npl/cli/InitCommandIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/InitCommandIT.kt
@@ -3,6 +3,7 @@ package com.noumenadigital.npl.cli
 import com.noumenadigital.npl.cli.TestUtils.getTestResourcesPath
 import com.noumenadigital.npl.cli.TestUtils.normalize
 import com.noumenadigital.npl.cli.TestUtils.runCommand
+import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import okhttp3.mockwebserver.MockResponse
@@ -41,7 +42,7 @@ class InitCommandIT :
             }
         }
 
-        test("Init command: Happy path using --name arg") {
+        test("Init command: Happy path using --path relative path") {
             var mockRepo = MockWebServer()
             val resourceDir = Paths.get("src/test/resources/test-files").toAbsolutePath().normalize()
             val repoArchive = resourceDir.resolve("samples.zip").toFile()
@@ -55,14 +56,14 @@ class InitCommandIT :
             )
 
             withInitTestContext(testDir = listOf("success")) {
-                runCommand(commands = listOf("init", "--name", "npl-app", "--templateUrl", mockRepo.url("/").toString())) {
+                runCommand(commands = listOf("init", "--projectDir", "npl-app", "--templateUrl", mockRepo.url("/").toString())) {
                     process.waitFor()
 
                     val projectDir = workingDirectory.resolve("npl-app")
                     val expectedOutput =
                         """
                     Successfully downloaded project files
-                    Project successfully saved to ${projectDir.canonicalFile.path}
+                    Project successfully saved to ${projectDir.relativeToCurrentOrAbsolute()}
                     """.normalize()
 
                     output.normalize() shouldBe expectedOutput
@@ -75,7 +76,41 @@ class InitCommandIT :
             mockRepo.shutdown()
         }
 
-        test("Init command: Happy path with no --name arg") {
+        test("Init command: Happy path using --path arg") {
+            var mockRepo = MockWebServer()
+            val resourceDir = Paths.get("src/test/resources/test-files").toAbsolutePath().normalize()
+            val repoArchive = resourceDir.resolve("samples.zip").toFile()
+            val buffer = Buffer().write(repoArchive.readBytes())
+
+            mockRepo.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/zip")
+                    .setBody(buffer),
+            )
+
+            withInitTestContext(testDir = listOf("success")) {
+                runCommand(commands = listOf("init", "--projectDir", "npl-app", "--templateUrl", mockRepo.url("/").toString())) {
+                    process.waitFor()
+
+                    val projectDir = workingDirectory.resolve("npl-app")
+                    val expectedOutput =
+                        """
+                    Successfully downloaded project files
+                    Project successfully saved to ${projectDir.relativeToCurrentOrAbsolute()}
+                    """.normalize()
+
+                    output.normalize() shouldBe expectedOutput
+                    projectDir.exists() shouldBe true
+                    projectDir.walk().filter { it.isDirectory }.count() shouldBe 11
+                    projectDir.walk().filter { it.isFile }.count() shouldBe 11
+                    process.exitValue() shouldBe ExitCode.SUCCESS.code
+                }
+            }
+            mockRepo.shutdown()
+        }
+
+        test("Init command: Happy path with no --projectDir arg") {
             var mockRepo = MockWebServer()
             val resourceDir = Paths.get("src/test/resources/test-files").toAbsolutePath().normalize()
             val repoArchive = resourceDir.resolve("samples.zip").toFile()
@@ -159,7 +194,7 @@ class InitCommandIT :
             )
 
             withInitTestContext(testDir = listOf("success")) {
-                runCommand(commands = listOf("init", "--name", projectDir.name, "--templateUrl", mockRepo.url("/").toString())) {
+                runCommand(commands = listOf("init", "--projectDir", projectDir.name, "--templateUrl", mockRepo.url("/").toString())) {
                     process.waitFor()
 
                     val expectedOutput =
@@ -204,7 +239,7 @@ class InitCommandIT :
 
         test("Init command: Fail if unexpected arguments are given") {
             withInitTestContext(testDir = listOf("success")) {
-                runCommand(commands = listOf("init", "--name", projectDir.name, "--unexpected")) {
+                runCommand(commands = listOf("init", "--projectDir", projectDir.name, "--unexpected")) {
                     process.waitFor()
 
                     val expectedOutput =
@@ -221,12 +256,12 @@ class InitCommandIT :
         test("Init command: Fail if directory with project name already exists") {
             withInitTestContext(listOf("success")) {
                 projectDir.canonicalFile.mkdir()
-                runCommand(commands = listOf("init", "--name", projectDir.name)) {
+                runCommand(commands = listOf("init", "--projectDir", projectDir.name)) {
                     process.waitFor()
 
                     val expectedOutput =
                         """
-                    npl init: Directory ${projectDir.canonicalFile.path} already exists.
+                    npl init: Directory ${projectDir.relativeToCurrentOrAbsolute()} already exists.
                     """.normalize()
 
                     output.normalize() shouldBe expectedOutput
@@ -237,7 +272,7 @@ class InitCommandIT :
 
         test("Init command: --bare and --templateUrl options are mutually exclusive") {
             withInitTestContext(testDir = listOf("success")) {
-                runCommand(commands = listOf("init", "--name", projectDir.name, "--bare", "--templateUrl", "https://example.com")) {
+                runCommand(commands = listOf("init", "--projectDir", projectDir.name, "--bare", "--templateUrl", "https://example.com")) {
                     process.waitFor()
 
                     val expectedOutput =

--- a/src/test/kotlin/com/noumenadigital/npl/cli/InitCommandIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/InitCommandIT.kt
@@ -3,7 +3,7 @@ package com.noumenadigital.npl.cli
 import com.noumenadigital.npl.cli.TestUtils.getTestResourcesPath
 import com.noumenadigital.npl.cli.TestUtils.normalize
 import com.noumenadigital.npl.cli.TestUtils.runCommand
-import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
+import com.noumenadigital.npl.cli.util.relativeOrAbsolute
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import okhttp3.mockwebserver.MockResponse
@@ -63,7 +63,7 @@ class InitCommandIT :
                     val expectedOutput =
                         """
                     Successfully downloaded project files
-                    Project successfully saved to ${projectDir.relativeToCurrentOrAbsolute()}
+                    Project successfully saved to ${projectDir.relativeOrAbsolute()}
                     """.normalize()
 
                     output.normalize() shouldBe expectedOutput
@@ -97,7 +97,7 @@ class InitCommandIT :
                     val expectedOutput =
                         """
                     Successfully downloaded project files
-                    Project successfully saved to ${projectDir.relativeToCurrentOrAbsolute()}
+                    Project successfully saved to ${projectDir.relativeOrAbsolute()}
                     """.normalize()
 
                     output.normalize() shouldBe expectedOutput
@@ -170,7 +170,7 @@ class InitCommandIT :
                     val expectedOutput =
                         """
                     Successfully downloaded project files
-                    Project successfully saved to ${workingDirectory.absolutePath}
+                    Project successfully saved to ${workingDirectory.normalize().absolutePath}
                     """.normalize()
 
                     (commonFiles + newFiles).forEach {
@@ -261,7 +261,7 @@ class InitCommandIT :
 
                     val expectedOutput =
                         """
-                    npl init: Directory ${projectDir.relativeToCurrentOrAbsolute()} already exists.
+                    npl init: Directory ${projectDir.relativeOrAbsolute()} already exists.
                     """.normalize()
 
                     output.normalize() shouldBe expectedOutput

--- a/src/test/kotlin/com/noumenadigital/npl/cli/PumlCommandIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/PumlCommandIT.kt
@@ -3,6 +3,7 @@ package com.noumenadigital.npl.cli
 import com.noumenadigital.npl.cli.TestUtils.getTestResourcesPath
 import com.noumenadigital.npl.cli.TestUtils.normalize
 import com.noumenadigital.npl.cli.TestUtils.runCommand
+import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
@@ -57,7 +58,7 @@ class PumlCommandIT :
                         """
                     Completed compilation for 4 files in XXX ms
 
-                    Writing Puml files to ${pumlDir.canonicalFile.path}
+                    Writing Puml files to ${pumlDir.relativeToCurrentOrAbsolute()}
 
                     Puml diagram generated successfully.
                     """.normalize()
@@ -86,7 +87,7 @@ class PumlCommandIT :
                         """
                         Completed compilation for 4 files in XXX ms
 
-                        Writing Puml files to ${pumlDir.canonicalFile.path}
+                        Writing Puml files to ${pumlDir.relativeToCurrentOrAbsolute()}
 
                         Puml diagram generated successfully.
                         """.normalize()

--- a/src/test/kotlin/com/noumenadigital/npl/cli/PumlCommandIT.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/PumlCommandIT.kt
@@ -3,7 +3,7 @@ package com.noumenadigital.npl.cli
 import com.noumenadigital.npl.cli.TestUtils.getTestResourcesPath
 import com.noumenadigital.npl.cli.TestUtils.normalize
 import com.noumenadigital.npl.cli.TestUtils.runCommand
-import com.noumenadigital.npl.cli.util.relativeToCurrentOrAbsolute
+import com.noumenadigital.npl.cli.util.relativeOrAbsolute
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
@@ -58,7 +58,7 @@ class PumlCommandIT :
                         """
                     Completed compilation for 4 files in XXX ms
 
-                    Writing Puml files to ${pumlDir.relativeToCurrentOrAbsolute()}
+                    Writing Puml files to ${pumlDir.relativeOrAbsolute()}
 
                     Puml diagram generated successfully.
                     """.normalize()
@@ -87,7 +87,7 @@ class PumlCommandIT :
                         """
                         Completed compilation for 4 files in XXX ms
 
-                        Writing Puml files to ${pumlDir.relativeToCurrentOrAbsolute()}
+                        Writing Puml files to ${pumlDir.relativeOrAbsolute()}
 
                         Puml diagram generated successfully.
                         """.normalize()

--- a/src/test/kotlin/com/noumenadigital/npl/cli/TestUtils.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/TestUtils.kt
@@ -68,6 +68,8 @@ object TestUtils {
         replace("\r\n", "\n")
             // Normalize path separators to forward slashes
             .replace('\\', '/')
+            // Normalize windows drive letters
+            .replace(Regex("[A-Z]:/"), "/")
             // Normalize durations
             .replace(Regex("in \\d+ ms"), "in XXX ms")
             .replace(Regex("\\d+%"), "XXX%")

--- a/src/test/kotlin/com/noumenadigital/npl/cli/service/CommandProcessorServiceTest.kt
+++ b/src/test/kotlin/com/noumenadigital/npl/cli/service/CommandProcessorServiceTest.kt
@@ -36,7 +36,7 @@ class CommandProcessorServiceTest :
                     version    Display the current version of the NPL CLI
                     help       Display the description for npl-cli commands
                     init       Initializes a new project
-                                 --name <name>  Name of the project. A directory of this name will be created in the current directory
+                                 --projectDir <projectDir>  Directory where project files will be stored. Created if it doesn’t exist
                                  --bare  Installs an empty project structure (defaults to false)
                                  --templateUrl <templateUrl>  URL of a repository containing a ZIP archive of the project template. Overrides the default template
                     check      Validate the correctness of NPL sources


### PR DESCRIPTION
In this PR:
- All commands now supports absolute or relative pathing
- All messaging will give relative pathing unless the path is outside of the working directory, in which case the absolute path will be given.
- previous Init command --name was changed to --projectDir

Ticket: ST-4601
