### PR TITLE
Show user tenants and applications

### DIFF
--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/CloudCommands.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/CloudCommands.kt
@@ -6,6 +6,7 @@ import com.noumenadigital.npl.cli.commands.registry.cloud.CloudDeployCommand
 import com.noumenadigital.npl.cli.commands.registry.cloud.CloudHelpCommand
 import com.noumenadigital.npl.cli.commands.registry.cloud.CloudLoginCommand
 import com.noumenadigital.npl.cli.commands.registry.cloud.CloudLogoutCommand
+import com.noumenadigital.npl.cli.commands.registry.cloud.CloudStatusCommand
 import com.noumenadigital.npl.cli.exception.CommandNotFoundException
 
 enum class CloudCommands(
@@ -16,6 +17,7 @@ enum class CloudCommands(
     CLOUD_HELP({ CloudHelpCommand }),
     CLOUD_CLEAR_NPL({ CloudClearNplCommand() }),
     CLOUD_DEPLOY({ CloudDeployCommand() }),
+    CLOUD_STATUS({ CloudStatusCommand() }),
     ;
 
     companion object {

--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/cloud/CloudStatusCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/cloud/CloudStatusCommand.kt
@@ -1,0 +1,111 @@
+package com.noumenadigital.npl.cli.commands.registry.cloud
+
+import com.noumenadigital.npl.cli.ExitCode
+import com.noumenadigital.npl.cli.commands.CommandArgumentParser
+import com.noumenadigital.npl.cli.commands.NamedParameter
+import com.noumenadigital.npl.cli.commands.registry.CommandExecutor
+import com.noumenadigital.npl.cli.exception.CloudCommandException
+import com.noumenadigital.npl.cli.http.NoumenaCloudAuthClient
+import com.noumenadigital.npl.cli.http.NoumenaCloudAuthConfig
+import com.noumenadigital.npl.cli.http.NoumenaCloudClient
+import com.noumenadigital.npl.cli.http.NoumenaCloudConfig
+import com.noumenadigital.npl.cli.service.CloudAuthManager
+import com.noumenadigital.npl.cli.service.ColorWriter
+
+class CloudStatusCommand(
+    private val cloudAuthManager: CloudAuthManager = CloudAuthManager(),
+    private val cloudClient: NoumenaCloudClient = NoumenaCloudClient(NoumenaCloudConfig()),
+) : CommandExecutor {
+    override val commandName: String = "cloud status"
+    override val description: String = "Show tenants and applications for the logged-in user"
+
+    override val parameters: List<NamedParameter> =
+        listOf(
+            NamedParameter(
+                name = "url",
+                description = "NOUMENA Cloud base URL",
+                isRequired = false,
+                isHidden = true,
+                valuePlaceholder = "<url>",
+            ),
+            NamedParameter(
+                name = "clientId",
+                description = "OAuth2 Client ID",
+                isRequired = false,
+                isHidden = true,
+                valuePlaceholder = "<clientId>",
+            ),
+            NamedParameter(
+                name = "clientSecret",
+                description = "OAuth2 Client Secret",
+                isRequired = false,
+                isHidden = true,
+                valuePlaceholder = "<clientSecret>",
+            ),
+            NamedParameter(
+                name = "authUrl",
+                description = "NOUMENA Cloud Auth URL",
+                isRequired = false,
+                isHidden = true,
+                valuePlaceholder = "<authUrl>",
+            ),
+        )
+
+    override fun createInstance(params: List<String>): CommandExecutor {
+        val parsedArgs = CommandArgumentParser.parse(params, parameters)
+        val url = parsedArgs.getValue("url")
+        val clientId = parsedArgs.getValue("clientId")
+        val clientSecret = parsedArgs.getValue("clientSecret")
+        val authUrl = parsedArgs.getValue("authUrl")
+
+        val noumenaCloudAuthClient = NoumenaCloudAuthClient(NoumenaCloudAuthConfig.get(clientId, clientSecret, authUrl))
+        val authManager = CloudAuthManager(noumenaCloudAuthClient)
+        val client = NoumenaCloudClient(NoumenaCloudConfig.get(appSlug = "", tenantSlug = "", url = url))
+
+        return CloudStatusCommand(authManager, client)
+    }
+
+    override fun execute(output: ColorWriter): ExitCode {
+        try {
+            val token = cloudAuthManager.getToken()
+            val accessToken = token.accessToken ?: throw CloudCommandException("No access token available. Please login again.")
+            val tenants = cloudClient.fetchTenants(accessToken)
+
+            if (tenants.isEmpty()) {
+                output.info("No tenants found for the current user.")
+                return ExitCode.SUCCESS
+            }
+
+            tenants.forEachIndexed { tenantIndex, tenant ->
+                val tenantHeader = "Tenant: ${tenant.name} (${tenant.slug})" + (tenant.state?.let { " [${it}]" } ?: "")
+                if (tenantIndex > 0) output.info()
+                output.success(tenantHeader)
+
+                if (tenant.applications.isEmpty()) {
+                    output.info("  Applications: none")
+                } else {
+                    output.info("  Applications:")
+                    tenant.applications.forEach { app ->
+                        val appLine = buildString {
+                            append("  - ${app.name} (${app.slug})")
+                            app.state?.let { append(" [${it}]") }
+                        }
+                        output.info(appLine)
+
+                        app.engineVersion?.version?.let { output.info("      engine: ${it}${if (app.engineVersion.deprecated == true) " (deprecated)" else ""}") }
+                        app.links?.api?.let { output.info("      api: ${it}") }
+                        app.links?.graphql?.let { output.info("      graphql: ${it}") }
+                        app.links?.swagger?.let { output.info("      swagger: ${it}") }
+                        app.links?.inspector?.let { output.info("      inspector: ${it}") }
+                        app.websiteUrl?.let { output.info("      website: ${it}") }
+                    }
+                }
+            }
+
+            return ExitCode.SUCCESS
+        } catch (ex: Exception) {
+            throw CloudCommandException(ex.message, ex, "cloud status")
+        }
+    }
+}
+

--- a/src/main/kotlin/com/noumenadigital/npl/cli/model/Application.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/model/Application.kt
@@ -1,10 +1,15 @@
 package com.noumenadigital.npl.cli.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Application(
     val id: String,
     val name: String,
     val slug: String,
+    @JsonProperty("engine_version") val engineVersion: EngineVersion? = null,
+    val state: String? = null,
+    val links: Links? = null,
+    @JsonProperty("website_url") val websiteUrl: String? = null,
 )

--- a/src/main/kotlin/com/noumenadigital/npl/cli/model/EngineVersion.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/model/EngineVersion.kt
@@ -1,0 +1,10 @@
+package com.noumenadigital.npl.cli.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class EngineVersion(
+    val version: String? = null,
+    val deprecated: Boolean? = null,
+)
+

--- a/src/main/kotlin/com/noumenadigital/npl/cli/model/Links.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/model/Links.kt
@@ -1,0 +1,12 @@
+package com.noumenadigital.npl.cli.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Links(
+    val api: String? = null,
+    val graphql: String? = null,
+    val swagger: String? = null,
+    val inspector: String? = null,
+)
+

--- a/src/main/kotlin/com/noumenadigital/npl/cli/model/Tenant.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/model/Tenant.kt
@@ -1,10 +1,13 @@
 package com.noumenadigital.npl.cli.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Tenant(
     val name: String,
     val slug: String,
     val applications: List<Application>,
+    val id: String? = null,
+    val state: String? = null,
 )


### PR DESCRIPTION
<!-- Description of the PR changes -->
Implements the `npl cloud status` command to display a logged-in user's tenants and their associated applications. This provides a quick overview of cloud resources, including tenant state, application state, engine version, and relevant links (API, GraphQL, Swagger, Inspector, Website URL).

Ticket: ST-XXXX

---
<a href="https://cursor.com/background-agent?bcId=bc-b2793a1d-b17b-49b8-8c5c-962068537016">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b2793a1d-b17b-49b8-8c5c-962068537016">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

