### PR TITLE
DVX-332 Add is-your-engine-running to DeploymentFailed error message

### DIFF
--- a/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/DeployCommand.kt
+++ b/src/main/kotlin/com/noumenadigital/npl/cli/commands/registry/DeployCommand.kt
@@ -158,7 +158,7 @@ class DeployCommand(
             }
 
             is DeployResult.DeploymentFailed -> {
-                output.error("Error deploying NPL sources: ${deployResult.exception.message ?: "Unknown deployment failure"}")
+                output.error("Error deploying NPL sources: ${deployResult.exception.message ?: "Unknown deployment failure"}. In case of Authorization exception, check the target Engine is running and the credentials used in the deploy.yml configuration file.")
                 ExitCode.GENERAL_ERROR
             }
 


### PR DESCRIPTION
Add "Is your engine running? Check credentials."-like text to standard error message thrown on deployment failure, to help in arguably the most common sources of errors.

Ticket: DVX-332
